### PR TITLE
Validate Seeder IP whilst loading config

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type config struct {
 	Host       string `short:"H" long:"host" description:"Seed DNS address"`
 	Listen     string `long:"listen" short:"l" description:"Listen on address:port"`
 	Nameserver string `short:"n" long:"nameserver" description:"hostname of nameserver"`
-	Seeder     string `short:"s" long:"default seeder" description:"IP address of a  working node"`
+	Seeder     string `short:"s" long:"default seeder" description:"IP address of a working node"`
 	TestNet    bool   `long:"testnet" description:"Use testnet"`
 
 	netParams *chaincfg.Params
@@ -118,6 +118,13 @@ func loadConfig() (*config, error) {
 	if len(cfg.Seeder) == 0 {
 		str := "Please specify a seeder"
 		err := fmt.Errorf(str)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+
+	if net.ParseIP(cfg.Seeder) == nil {
+		str := "\"%s\" is not a valid textual representation of an IP address"
+		err := fmt.Errorf(str, cfg.Seeder)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -53,10 +53,7 @@ func loadConfig() (*config, error) {
 			}
 		}
 
-		str := "failed to create home directory: %v"
-		err := fmt.Errorf(str, err)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create home directory: %v", err)
 	}
 
 	// Default config.
@@ -102,31 +99,20 @@ func loadConfig() (*config, error) {
 	}
 
 	if len(cfg.Host) == 0 {
-		str := "Please specify a hostname"
-		err := fmt.Errorf(str)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
+		return nil, fmt.Errorf("Please specify a hostname")
 	}
 
 	if len(cfg.Nameserver) == 0 {
-		str := "Please specify a nameserver"
-		err := fmt.Errorf(str)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
+		return nil, fmt.Errorf("Please specify a nameserver")
 	}
 
 	if len(cfg.Seeder) == 0 {
-		str := "Please specify a seeder"
-		err := fmt.Errorf(str)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
+		return nil, fmt.Errorf("Please specify a seeder")
 	}
 
 	if net.ParseIP(cfg.Seeder) == nil {
 		str := "\"%s\" is not a valid textual representation of an IP address"
-		err := fmt.Errorf(str, cfg.Seeder)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
+		return nil, fmt.Errorf(str, cfg.Seeder)
 	}
 
 	cfg.Listen = normalizeAddress(cfg.Listen, defaultListenPort)

--- a/manager.go
+++ b/manager.go
@@ -348,4 +348,6 @@ func (m *Manager) savePeers() {
 		log.Printf("Error writing file %s: %v", m.peersFile, err)
 		return
 	}
+
+	log.Printf("%d nodes saved to %s", len(m.nodes), m.peersFile)
 }

--- a/manager.go
+++ b/manager.go
@@ -320,7 +320,7 @@ func (m *Manager) deserializePeers() error {
 	m.nodes = nodes
 	m.mtx.Unlock()
 
-	log.Printf("%d nodes loaded", l)
+	log.Printf("%d nodes loaded from %s", l, filePath)
 	return nil
 }
 


### PR DESCRIPTION
### Parse seeder IP in config.go. 

ParseIP returns nil when given invalid input. Parsing the seeder IP once in config.go means that we dont need to perform additional nil checks later on.

Without this change, the application accepts invalid input, ParseIP returns nil and things behave strangely. For example, a record with IP address "nil" is stored in nodes.json.

### Don't log error messages twice.

Errors in loadConfig are currently being logged twice. Once when they occur in loadConfig, and once by the calling code. This removes the logging from inside loadConfig.
