### PR TITLE
graceful shutdown

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	defaultConfigFilename = "dcrseeder.conf"
+	appName               = "dcrseeder"
+	defaultConfigFilename = appName + ".conf"
 	defaultDNSPort        = "5354"
 	defaultHTTPPort       = "8000"
 )
@@ -26,7 +27,7 @@ const (
 var (
 	// Default configuration options
 	defaultConfigFile = filepath.Join(defaultHomeDir, defaultConfigFilename)
-	defaultHomeDir    = dcrutil.AppDataDir("dcrseeder", false)
+	defaultHomeDir    = dcrutil.AppDataDir(appName, false)
 )
 
 // config defines the configuration options for dcrseeder.

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/decred.go
+++ b/decred.go
@@ -1,14 +1,16 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sync"
 	"time"
@@ -19,39 +21,40 @@ import (
 )
 
 const (
-	// defaultAddressTimeout defines the duration to wait
-	// for new addresses.
+	// defaultAddressTimeout defines the duration to wait for new addresses.
 	defaultAddressTimeout = time.Minute * 10
 
-	// defaultNodeTimeout defines the timeout time waiting for
-	// a response from a node.
+	// defaultNodeTimeout defines the timeout on responses from a node.
 	defaultNodeTimeout = time.Second * 3
 )
 
-var (
-	amgr *Manager
-	wg   sync.WaitGroup
-)
+var amgr *Manager
 
-func creep(netParams *chaincfg.Params) {
-	defer wg.Done()
-
-	var wg sync.WaitGroup
+func creep(ctx context.Context, netParams *chaincfg.Params) {
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		ips := amgr.Addresses()
 		if len(ips) == 0 {
-			log.Printf("No stale addresses -- sleeping for %v",
-				defaultAddressTimeout)
-			time.Sleep(defaultAddressTimeout)
+			log.Printf("No stale addresses -- sleeping for %v", defaultAddressTimeout)
+			select {
+			case <-time.After(defaultAddressTimeout):
+			case <-ctx.Done():
+				return
+			}
 			continue
 		}
 
+		var wg sync.WaitGroup
 		wg.Add(len(ips))
 
 		for _, ip := range ips {
-
-			onaddr := make(chan struct{})
-			verack := make(chan struct{})
+			onaddr := make(chan struct{}, 1)
+			verack := make(chan struct{}, 1)
 			config := peer.Config{
 				UserAgentName:    appName,
 				UserAgentVersion: "0.0.1",
@@ -81,24 +84,25 @@ func creep(netParams *chaincfg.Params) {
 			go func(ip net.IP) {
 				defer wg.Done()
 
-				host := net.JoinHostPort(ip.String(),
-					netParams.DefaultPort)
+				host := net.JoinHostPort(ip.String(), netParams.DefaultPort)
 				p, err := peer.NewOutboundPeer(&config, host)
 				if err != nil {
-					log.Printf("NewOutboundPeer on %v: %v",
-						host, err)
+					log.Printf("NewOutboundPeer on %v: %v", host, err)
 					return
 				}
+
 				amgr.Attempt(ip)
-				conn, err := net.DialTimeout("tcp", p.Addr(),
-					defaultNodeTimeout)
+				ctxTimeout, cancel := context.WithTimeout(ctx, defaultNodeTimeout)
+				defer cancel()
+				var dialer net.Dialer
+				conn, err := dialer.DialContext(ctxTimeout, "tcp", p.Addr())
 				if err != nil {
 					return
 				}
 				p.AssociateConnection(conn)
+				defer p.Disconnect()
 
-				// Wait for the verack message or timeout in case of
-				// failure.
+				// Wait for the verack message or timeout in case of failure.
 				select {
 				case <-verack:
 					// Mark this peer as a good node.
@@ -108,21 +112,18 @@ func creep(netParams *chaincfg.Params) {
 					p.QueueMessage(wire.NewMsgGetAddr(), nil)
 
 				case <-time.After(defaultNodeTimeout):
-					log.Printf("verack timeout on peer %v",
-						p.Addr())
-					p.Disconnect()
+					log.Printf("verack timeout on peer %v", p.Addr())
+					return
+				case <-ctx.Done():
 					return
 				}
 
 				select {
 				case <-onaddr:
 				case <-time.After(defaultNodeTimeout):
-					log.Printf("getaddr timeout on peer %v",
-						p.Addr())
-					p.Disconnect()
-					return
+					log.Printf("getaddr timeout on peer %v", p.Addr())
+				case <-ctx.Done():
 				}
-				p.Disconnect()
 			}(ip)
 		}
 		wg.Wait()
@@ -144,17 +145,42 @@ func main() {
 
 	amgr.AddAddresses([]net.IP{net.ParseIP(cfg.Seeder)})
 
+	ctx, shutdown := context.WithCancel(context.Background())
+	killSwitch := make(chan os.Signal, 1)
+	signal.Notify(killSwitch, os.Interrupt)
+	go func() {
+		<-killSwitch
+		log.Print("Shutting down...")
+		shutdown()
+	}()
+
+	var wg sync.WaitGroup
 	wg.Add(1)
-	go creep(cfg.netParams)
+	go func() {
+		defer wg.Done()
+		creep(ctx, cfg.netParams) // only returns on context cancellation
+		log.Print("Crawler done.")
+	}()
 
 	if cfg.HTTPListen != "" {
-		go httpServer(cfg.HTTPListen)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := serveHTTP(ctx, cfg.HTTPListen); err != nil {
+				log.Fatal(err)
+				shutdown()
+			}
+			log.Print("HTTP server done.")
+		}()
 	}
 
 	if cfg.DNSListen != "" {
 		dnsServer := NewDNSServer(cfg.Host, cfg.Nameserver, cfg.DNSListen)
-		go dnsServer.Start()
+		go dnsServer.Start() // no graceful shutdown
 	}
 
+	// Wait for crawler and http server, then stop address manager.
 	wg.Wait()
+	amgr.Stop()
+	log.Print("Bye!")
 }

--- a/decred.go
+++ b/decred.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/v3"
@@ -146,7 +147,7 @@ func main() {
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	killSwitch := make(chan os.Signal, 1)
-	signal.Notify(killSwitch, os.Interrupt)
+	signal.Notify(killSwitch, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-killSwitch
 		log.Print("Shutting down...")

--- a/decred.go
+++ b/decred.go
@@ -53,7 +53,7 @@ func creep(netParams *chaincfg.Params) {
 			onaddr := make(chan struct{})
 			verack := make(chan struct{})
 			config := peer.Config{
-				UserAgentName:    "dcrseeder",
+				UserAgentName:    appName,
 				UserAgentVersion: "0.0.1",
 				Net:              netParams.Net,
 				DisableRelayTx:   true,

--- a/dns.go
+++ b/dns.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dns.go
+++ b/dns.go
@@ -22,8 +22,6 @@ type DNSServer struct {
 }
 
 func (d *DNSServer) Start() {
-	defer wg.Done()
-
 	rr := fmt.Sprintf("%s 86400 IN NS %s", d.hostname, d.nameserver)
 	authority, err := dns.NewRR(rr)
 	if err != nil {

--- a/dns.go
+++ b/dns.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrseeder
 
-go 1.13
+go 1.14
 
 require (
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0

--- a/http.go
+++ b/http.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package main
 
 import (
@@ -45,7 +49,10 @@ func httpGetAddrs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8") // not a json array
+	// Replace the Server response header. When used with nginx's "server_tokens
+	// off;" and "proxy_pass_header Server;" options.
+	w.Header().Set("Server", appName)
 	w.WriteHeader(http.StatusOK)
 	flush.Flush()
 
@@ -55,13 +62,11 @@ func httpGetAddrs(w http.ResponseWriter, r *http.Request) {
 	for _, node := range nodes {
 		select {
 		case <-ctx.Done():
-			log.Printf("client close connection")
 			return
 		default:
 			err := enc.Encode(node)
 			if err != nil {
-				log.Printf("httpGetAddrs: Encode failed: %v",
-					err)
+				log.Printf("httpGetAddrs: Encode failed: %v", err)
 			}
 			flush.Flush()
 		}

--- a/http.go
+++ b/http.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/manager.go
+++ b/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/manager.go
+++ b/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -48,7 +48,7 @@ const (
 
 	// dumpAddressInterval is the interval used to dump the address
 	// cache to disk for future use.
-	dumpAddressInterval = time.Second * 30
+	dumpAddressInterval = time.Minute * 5
 
 	// peersFilename is the name of the file.
 	peersFilename = "nodes.json"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
-# The script does automatic checking on a Go package and its sub-packages, including:
-# 1. gofmt         (http://golang.org/cmd/gofmt/)
-# 2. go vet        (http://golang.org/cmd/vet)
-# 3. gosimple      (https://github.com/dominikh/go-simple)
-# 4. unconvert     (https://github.com/mdempsky/unconvert)
-# 5. ineffassign   (https://github.com/gordonklaus/ineffassign)
-# 6. race detector (http://blog.golang.org/race-detector)
-# 7. test coverage (http://blog.golang.org/cover)
+# The script does the following automatic checking on a Go package and its sub-packages:
+# 1. go mod tidiness
+# 2. unit tests
+# 3. linting (github.com/golangci/golangci-lint)
 
 set -ex
 


### PR DESCRIPTION
Previously, shutdown with sigint just killed the app in the middle of whatever it was doing (e.g. writing out json, responding to http client, etc.).  None of the waitgroups or anything were being used, but that's just as well because they weren't balanced and would have panicked.

This catches SIGINT and gracefully shuts everything down.

```
^C2020/12/24 16:51:43 Shutting down...
2020/12/24 16:51:43 Crawler done.
2020/12/24 16:51:44 HTTP server done.
2020/12/24 16:51:44 134 nodes saved to /home/dcrseeder/.dcrseeder/testnet3/nodes.json
2020/12/24 16:51:44 Address manager done.
2020/12/24 16:51:44 Bye!
```