### PR TITLE
Use go 1.18 net.IP.IsPrivate()

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.16, 1.17]
+        go: [1.17, 1.18]
 
     steps:
       - name: Set up Go
@@ -17,7 +17,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
+*.exe
 dcrseeder
 vendor/
+
+# Testing, profiling, and benchmarking artifacts
+cov.out
+*cpu.out
+*mem.out
+
+# Go 1.18 workspace
+go.work
+go.work.sum

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2018-2020 The Decred developers
+Copyright (c) 2018-2022 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-dcrseeder
-=========
+# dcrseeder
 
 [![Build Status](https://github.com/decred/dcrseeder/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrseeder/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
@@ -24,7 +23,7 @@ random selection of the reliable nodes it knows about.
 
 ## Requirements
 
-[Go](https://golang.org) 1.14 or newer.
+[Go](https://golang.org) 1.17 or newer.
 
 ### Getting Started
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrseeder
 
-go 1.14
+go 1.17
 
 require (
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
@@ -9,4 +9,24 @@ require (
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/miekg/dns v1.1.35
+)
+
+require (
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dchest/siphash v1.2.1 // indirect
+	github.com/decred/base58 v1.0.3 // indirect
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.2 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+	github.com/decred/dcrd/crypto/ripemd160 v1.0.1 // indirect
+	github.com/decred/dcrd/dcrec v1.0.0 // indirect
+	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
+	github.com/decred/dcrd/lru v1.1.0 // indirect
+	github.com/decred/dcrd/txscript/v3 v3.0.0 // indirect
+	github.com/decred/go-socks v1.1.0 // indirect
+	github.com/decred/slog v1.1.0 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect
 )

--- a/ip.go
+++ b/ip.go
@@ -7,39 +7,28 @@ package main
 import "net"
 
 var (
-	// rfc1918Nets specifies the IPv4 private address blocks as defined by
-	// by RFC1918 (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16).
-	rfc1918Nets = []net.IPNet{
-		ipNet("10.0.0.0", 8, 32),
-		ipNet("172.16.0.0", 12, 32),
-		ipNet("192.168.0.0", 16, 32),
-	}
-
 	// rfc3964Net specifies the IPv6 to IPv4 encapsulation address block as
 	// defined by RFC3964 (2002::/16).
-	rfc3964Net = ipNet("2002::", 16, 128)
+	rfc3964Net = ipNet("2002::", 16)
 
 	// rfc4380Net specifies the IPv6 teredo tunneling over UDP address block
 	// as defined by RFC4380 (2001::/32).
-	rfc4380Net = ipNet("2001::", 32, 128)
+	rfc4380Net = ipNet("2001::", 32)
 
 	// rfc4843Net specifies the IPv6 ORCHID address block as defined by
 	// RFC4843 (2001:10::/28).
-	rfc4843Net = ipNet("2001:10::", 28, 128)
+	rfc4843Net = ipNet("2001:10::", 28)
 
 	// rfc4862Net specifies the IPv6 stateless address autoconfiguration
 	// address block as defined by RFC4862 (FE80::/64).
-	rfc4862Net = ipNet("FE80::", 64, 128)
-
-	// rfc4193Net specifies the IPv6 unique local address block as defined
-	// by RFC4193 (FC00::/7).
-	rfc4193Net = ipNet("FC00::", 7, 128)
+	rfc4862Net = ipNet("FE80::", 64)
 )
 
 // ipNet returns a net.IPNet struct given the passed IP address string, number
 // of one bits to include at the start of the mask, and the total number of bits
 // for the mask.
-func ipNet(ip string, ones, bits int) net.IPNet {
+func ipNet(ip string, ones int) net.IPNet {
+	const bits = 128
 	return net.IPNet{IP: net.ParseIP(ip), Mask: net.CIDRMask(ones, bits)}
 }
 
@@ -52,17 +41,14 @@ func isRoutable(addr net.IP) bool {
 		return false
 	}
 
-	for _, n := range rfc1918Nets {
-		if n.Contains(addr) {
-			return false
-		}
+	if addr.IsPrivate() {
+		return false
 	}
 
 	if rfc3964Net.Contains(addr) ||
 		rfc4380Net.Contains(addr) ||
 		rfc4843Net.Contains(addr) ||
-		rfc4862Net.Contains(addr) ||
-		rfc4193Net.Contains(addr) {
+		rfc4862Net.Contains(addr) {
 		return false
 	}
 

--- a/ip.go
+++ b/ip.go
@@ -44,11 +44,20 @@ func ipNet(ip string, ones, bits int) net.IPNet {
 }
 
 func isRoutable(addr net.IP) bool {
+	if addr.IsLoopback() {
+		return false
+	}
+
+	if addr.IsUnspecified() {
+		return false
+	}
+
 	for _, n := range rfc1918Nets {
 		if n.Contains(addr) {
 			return false
 		}
 	}
+
 	if rfc3964Net.Contains(addr) ||
 		rfc4380Net.Contains(addr) ||
 		rfc4843Net.Contains(addr) ||

--- a/ip_test.go
+++ b/ip_test.go
@@ -10,32 +10,135 @@ import (
 )
 
 func Test_IsRoutable(t *testing.T) {
-	ipTests := []struct {
+	ipTests := map[string]struct {
 		ip               string
 		expectedRoutable bool
 	}{
-		{
+
+		// IP v4
+		"ip4 public": {
+			"8.8.8.8",
+			true,
+		},
+
+		"ip4 unspecified": {
+			"0.0.0.0",
+			false,
+		},
+		"ip4 loopback": {
+			"127.0.0.1",
+			false,
+		},
+
+		// RFC1918
+		"ip4 inside RFC1918 (10)": {
 			"10.0.0.2",
 			false,
 		},
-		{
+		"ip4 inside RFC1918 (172)": {
 			"172.16.0.2",
 			false,
 		},
-		{
+		"ip4 outside RFC1918 (172)": {
+			"172.32.0.1",
+			true,
+		},
+		"ip4 inside RFC1918 (192)": {
 			"192.168.1.2",
 			false,
 		},
-		{
-			"8.8.8.8",
+		"ip4 outside RFC1918 (192)": {
+			"192.169.0.1",
+			true,
+		},
+
+		// IP v6
+
+		"ip6 public": {
+			"2001:4860:4860::8888",
+			true,
+		},
+		"ip6 unspecified": {
+			"::",
+			false,
+		},
+		"ip6 loopback": {
+			"::1",
+			false,
+		},
+
+		// RFC3964
+		"ip6 start RFC3964": {
+			"2002:0000:0000:0000:0000:0000:0000:0000",
+			false,
+		},
+		"ip6 end RFC3964": {
+			"2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			false,
+		},
+
+		// RFC4380
+		"ip6 start RFC4380": {
+			"2001:0000:0000:0000:0000:0000:0000:0000",
+			false,
+		},
+		"ip6 end RFC4380": {
+			"2001:0000:ffff:ffff:ffff:ffff:ffff:ffff",
+			false,
+		},
+		"ip6 outside RFC4380": {
+			"2001:0001:0000:0000:0000:0000:0000:0000",
+			true,
+		},
+
+		// RFC4843
+		"ip6 start RFC4843": {
+			"2001:0010:0000:0000:0000:0000:0000:0000",
+			false,
+		},
+		"ip6 end RFC4843": {
+			"2001:001f:ffff:ffff:ffff:ffff:ffff:ffff",
+			false,
+		},
+		"ip6 outside RFC4843": {
+			"2001:0020:0000:0000:0000:0000:0000:0000",
+			true,
+		},
+
+		// RFC4862
+		"ip6 start RFC4862": {
+			"fe80:0000:0000:0000:0000:0000:0000:0000",
+			false,
+		},
+		"ip6 end RFC4862": {
+			"fe80:0000:0000:0000:ffff:ffff:ffff:ffff",
+			false,
+		},
+		"ip6 outside RFC4862": {
+			"fe80:0000:0000:0001:0000:0000:0000:0000",
+			true,
+		},
+
+		// RFC4193
+		"ip6 start RFC4193": {
+			"fc00:0000:0000:0000:0000:0000:0000:0000",
+			false,
+		},
+		"ip6 end RFC4193": {
+			"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			false,
+		},
+		"ip6 outside RFC4193": {
+			"fe00:0000:0000:0000:0000:0000:0000:0000",
 			true,
 		},
 	}
 
-	for _, test := range ipTests {
+	for testName, test := range ipTests {
 		actualRoutable := isRoutable(net.ParseIP(test.ip))
 		if actualRoutable != test.expectedRoutable {
-			t.Fatalf("expected routable==%t for IP %s", test.expectedRoutable, test.ip)
+			t.Fatalf("%s: expected routable==%t for IP %s",
+				testName, test.expectedRoutable, test.ip)
 		}
 	}
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,7 +36,7 @@ fi
 golangci-lint run --disable-all --deadline=10m \
   --out-format=$OUT_FORMAT \
   --enable=gofmt \
-  --enable=golint \
+  --enable=revive \
   --enable=govet \
   --enable=gosimple \
   --enable=unconvert \


### PR DESCRIPTION
Rebased on #51 

Removes the hard-coded ipv4 private IP address ranges, and also rejects loopback and zero addresses as these are not routable.