### PR TITLE
 build: Test against Go 1.20+ and modernize build.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.20", "1.21"]
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f #v3.3.1
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #4.1.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 #v4.1.0
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2"
       - name: Build
         run: go build ./...
       - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+run:
+  deadline: 10m
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - noctx
+    - revive
+    - unconvert
+    - unparam
+    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,15 +5,25 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
+    - durationcheck
     - errcheck
+    - errchkjson
+    - exhaustive
+    - exportloopref
+    - goconst
     - gofmt
     - goimports
     - gosimple
     - govet
     - ineffassign
     - misspell
-    - noctx
+    - nilerr
     - revive
+    - staticcheck
+    - tparallel
+    - typecheck
     - unconvert
     - unparam
     - unused
+    - vetshadow

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ random selection of the reliable nodes it knows about.
 
 ## Requirements
 
-[Go](https://golang.org) 1.19 or newer.
+[Go](https://golang.org) 1.20 or newer.
 
 ### Getting Started
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,16 +14,8 @@ env GORACE="halt_on_error=1" go test -race ./...
 # golangci-lint (github.com/golangci/golangci-lint) is used to run each each
 # static checker.
 
-# set output format
-if [[ -n $CI ]]; then
-    OUT_FORMAT="github-actions"
-else
-    OUT_FORMAT="colored-line-number"
-fi
-
 # run linter
 golangci-lint run --disable-all --deadline=10m \
-  --out-format=$OUT_FORMAT \
   --enable=gofmt \
   --enable=revive \
   --enable=govet \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,17 +8,6 @@ set -ex
 
 go version
 
-# run `go mod download` and `go mod tidy` and fail if the git status of
-# go.mod and/or go.sum changes
-MOD_STATUS=$(git status --porcelain go.mod go.sum)
-go mod download
-go mod tidy
-UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)
-if [ "$UPDATED_MOD_STATUS" != "$MOD_STATUS" ]; then
-    echo "Running `go mod tidy` modified go.mod and/or go.sum"
-    exit 1
-fi
-
 # run tests
 env GORACE="halt_on_error=1" go test -race ./...
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,18 +15,4 @@ env GORACE="halt_on_error=1" go test -race ./...
 # static checker.
 
 # run linter
-golangci-lint run --disable-all --deadline=10m \
-  --enable=gofmt \
-  --enable=revive \
-  --enable=govet \
-  --enable=gosimple \
-  --enable=unconvert \
-  --enable=ineffassign \
-  --enable=goimports \
-  --enable=misspell \
-  --enable=unparam \
-  --enable=unused \
-  --enable=errcheck \
-  --enable=asciicheck \
-  --enable=noctx
-
+golangci-lint run

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The script does the following automatic checking on a Go package and its sub-packages:
 # 1. go mod tidiness
 # 2. unit tests


### PR DESCRIPTION
This mainly updates build tooling to more closely match how things are configured in other Decred repos:

- Use go 1.21, latest GitHub Actions and linter
- Use a config file for linter
- Add some additional linters
- Remove outdated cruft from run_tests.sh