### PR TITLE
Remove quit chan from Manager

### DIFF
--- a/decred.go
+++ b/decred.go
@@ -159,6 +159,14 @@ func main() {
 	amgr.AddAddresses([]netip.AddrPort{seeder})
 
 	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		amgr.run(ctx) // only returns on context cancellation
+		log.Print("Address manager done.")
+	}()
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -177,6 +185,5 @@ func main() {
 
 	// Wait for crawler and http server, then stop address manager.
 	wg.Wait()
-	amgr.Stop()
 	log.Print("Bye!")
 }


### PR DESCRIPTION
Make the main loop of the Manager a blocking func which accepts a context. Shutdown the Manager when the context is canceled.

This slightly alters the semantics of the code but in a way that has functionally no impact. Previously the Tickers which update the Manager would only be stopped after the HTTP server and creeper had stopped, but now they are stopped immediately when the context is canceled.