### PR TITLE
Dual network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ dcrseeder is a crawler for the Decred network, which exposes a list of reliable
 nodes via a built-in HTTP server.
 
 When dcrseeder is started for the first time, it will connect to the dcrd node
-specified with the `-s` flag, send a `getaddrs` request, expecting an  `addr`
+specified in config, send a `getaddrs` request, expecting an `addr`
 message response. This message contains hostnames and IPs of peers known by the
 node. dcrseeder will then connect to each of these peers, send a `getaddrs`
 request, and will continue traversing the network in this fashion. dcrseeder
 maintains a list of all known peers and periodically checks that they are
 online and available. The list is stored on disk in a json file, so on
-subsequent start ups the dcrd node specified with `-s` does not need to be
+subsequent start ups the dcrd node specified in config does not need to be
 online.
 
 When dcrseeder is queried for node information, it responds with details of a
@@ -33,10 +33,12 @@ root directory.
 To start dcrseeder listening on localhost:8000 with an initial connection to working testnet node 192.168.0.1:
 
 ```no-highlight
-$ ./dcrseeder -s 192.168.0.1 --testnet --httplisten=localhost:8000
+$ ./dcrseeder --testnet.enabled --testnet.seeder 192.168.0.1 --testnet.listen=localhost:8000
 ```
 
 You will then need to redirect HTTPS traffic on your public IP to localhost:8000
+
+An [example configuration file](./sample-dcrseeder.conf) lists the full set of options available.
 
 ## Issue Tracker
 

--- a/decred.go
+++ b/decred.go
@@ -161,6 +161,8 @@ func run() int {
 		return 1
 	}
 
+	defer log.Print("Bye!")
+
 	// Prefix log lines with current network, e.g. "[mainnet]" or "[testnet]".
 	logPrefix := fmt.Sprintf("[%.7s] ", cfg.netParams.Name)
 	log := log.New(os.Stdout, logPrefix, log.LstdFlags|log.Lmsgprefix)
@@ -181,7 +183,10 @@ func run() int {
 		return 1
 	}
 
+	// Wait for all subsystems to shut down before returning and allowing the
+	// process to end.
 	var wg sync.WaitGroup
+	defer wg.Wait()
 
 	wg.Add(1)
 	go func() {
@@ -203,10 +208,6 @@ func run() int {
 		server.run(ctx) // Only returns on context cancellation.
 		log.Print("HTTP server done.")
 	}()
-
-	// Wait for crawler and http server, then stop address manager.
-	wg.Wait()
-	log.Print("Bye!")
 
 	return 0
 }

--- a/sample-dcrseeder.conf
+++ b/sample-dcrseeder.conf
@@ -1,0 +1,25 @@
+; ------------------------------------------------------------------------------
+; Mainnet settings
+; ------------------------------------------------------------------------------
+
+; Enable dcrseeder on mainnet.
+mainnet.enabled=1
+
+; HTTP listen on address:port (must be unique per network).
+mainnet.listen=127.0.0.1:8000
+
+; IP address of a working node on mainnet.
+mainnet.seeder=127.0.0.1
+
+; ------------------------------------------------------------------------------
+; Testnet settings
+; ------------------------------------------------------------------------------
+
+; Enable dcrseeder on testnet.
+testnet.enabled=1
+
+; HTTP listen on address:port (must be unique per network).
+testnet.listen=127.0.0.1:8001
+
+; IP address of a working node on testnet.
+testnet.seeder=127.0.0.1

--- a/signal.go
+++ b/signal.go
@@ -17,7 +17,7 @@ var interruptSignals = []os.Signal{os.Interrupt}
 
 // shutdownListener returns a context whose done channel will be closed when OS
 // signals such as SIGINT (Ctrl+C) are received.
-func shutdownListener() context.Context {
+func shutdownListener() (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		interruptChannel := make(chan os.Signal, 1)
@@ -39,5 +39,5 @@ func shutdownListener() context.Context {
 		}
 	}()
 
-	return ctx
+	return ctx, cancel
 }


### PR DESCRIPTION
dcrseeder is now able to run on mainnet and testnet simultaneously. It runs two HTTP servers on two different ports. This PR also adds a sample config file.

**Note: The config format has changed significantly to enable this change.**

Closes #14 
